### PR TITLE
Update projectEntitlements.js project paths for cordova-ios@8

### DIFF
--- a/hooks/beforePluginInstallHook.js
+++ b/hooks/beforePluginInstallHook.js
@@ -37,7 +37,7 @@ function createPluginInstalledFlag(ctx) {
 }
 // endregion
 
-module.exports = function(ctx) {
+module.exports = function (ctx) {
   if (isInstallationAlreadyPerformed(ctx)) {
     return;
   }
@@ -46,7 +46,9 @@ module.exports = function(ctx) {
   console.log(JSON.stringify(pluginNpmDependencies, null, 2));
 
   var npm = (process.platform === "win32" ? "npm.cmd" : "npm");
-  var result = spawnSync(npm, ['install', '--production'], { cwd: './plugins/' + ctx.opts.plugin.id });
+
+  var pluginPath = path.join(ctx.opts.projectRoot, 'plugins', ctx.opts.plugin.id);
+  var result = spawnSync(npm, ['install', '--production'], { cwd: pluginPath, shell: true });
   if (result.error) {
     throw result.error;
   }

--- a/hooks/lib/ios/projectEntitlements.js
+++ b/hooks/lib/ios/projectEntitlements.js
@@ -139,7 +139,12 @@ function domainsListEntryForHost(host) {
  * @return {String} absolute path to entitlements file
  */
 function pathToEntitlementsFile() {
-  return path.join(getProjectRoot(), 'platforms/ios/', getProjectName());
+  const projectRoot = context.opts.projectRoot;
+  const platformPath = path.join(projectRoot, 'platforms', 'ios');
+  const cordova_ios = require('cordova-ios');
+  const iosProject = new cordova_ios('ios', platformPath);
+  const infoPlistPath = path.join(iosProject.locations.xcodeCordovaProj);
+  return infoPlistPath;
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   ],
   "dependencies": {
     "mkpath": "^1.0.0",
-    "node-version-compare": "^1.0.3",
     "plist": "^3.1.0",
     "rimraf": "^6.1.2",
     "xml2js": "^0.6.2"

--- a/package.json
+++ b/package.json
@@ -26,11 +26,11 @@
     "android"
   ],
   "dependencies": {
-    "mkpath": ">=1.0.0",
-    "xml2js": ">=0.4",
-    "rimraf": ">=2.4",
-    "node-version-compare": ">=1.0.1",
-    "plist": ">=1.2.0"
+    "mkpath": "^1.0.0",
+    "node-version-compare": "^1.0.3",
+    "plist": "^3.1.0",
+    "rimraf": "^6.1.2",
+    "xml2js": "^0.6.2"
   },
   "author": "Nikolay Demyankov for Nordnet Bank AB",
   "license": "MIT",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<plugin id="cordova-universal-links-plugin" version="1.2.1" xmlns="http://apache.org/cordova/ns/plugins/1.0">
+<plugin id="cordova-universal-links-plugin" version="1.2.1"
+  xmlns="http://apache.org/cordova/ns/plugins/1.0">
 
   <name>Universal Links Plugin</name>
   <description>
@@ -45,6 +46,9 @@
 
     <source-file src="src/ios/AppDelegate+CULPlugin.m"/>
     <header-file src="src/ios/AppDelegate+CULPlugin.h"/>
+
+    <source-file src="src/ios/SceneDelegate+CULPlugin.m"/>
+    <header-file src="src/ios/SceneDelegate+CULPlugin.h"/>
 
 <!-- sources for JS folder -->
     <source-file src="src/ios/JS/CDVPluginResult+CULPlugin.m" target-dir="JS/"/>

--- a/src/ios/SceneDelegate+CULPlugin.h
+++ b/src/ios/SceneDelegate+CULPlugin.h
@@ -1,0 +1,20 @@
+//
+//  SceneDelegate+CULPlugin.h
+//
+//  Created for cordova-ios@8 Scene API support
+//  Handles Universal Links via SceneDelegate instead of AppDelegate
+//
+
+#import <UIKit/UIKit.h>
+#import <Cordova/CDVSceneDelegate.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface CDVSceneDelegate (CULPlugin)
+
+- (void)scene:(UIScene *)scene continueUserActivity:(NSUserActivity *)userActivity;
+
+@end
+
+NS_ASSUME_NONNULL_END
+

--- a/src/ios/SceneDelegate+CULPlugin.m
+++ b/src/ios/SceneDelegate+CULPlugin.m
@@ -1,0 +1,135 @@
+//
+//  SceneDelegate+CULPlugin.m
+//
+//  Created for cordova-ios@8 Scene API support
+//  Handles Universal Links via SceneDelegate instead of AppDelegate
+//
+
+#import "SceneDelegate+CULPlugin.h"
+#import "CULPlugin.h"
+#import <objc/runtime.h>
+#import <Cordova/CDV.h>
+
+/**
+ *  Plugin name in config.xml
+ */
+static NSString *const PLUGIN_NAME = @"UniversalLinks";
+
+@implementation CDVSceneDelegate (CULPlugin)
+
+/*
+ In cordova-ios@8, the app uses Scene API, so user activities come through SceneDelegate
+ instead of AppDelegate. We need to swizzle the SceneDelegate method to handle Universal Links.
+ */
++ (void)load {
+    NSLog(@"[UniversalLinks] ===== LOADING UniversalLinks Category =====");
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        // Swizzle CDVSceneDelegate directly since SceneDelegate inherits from it
+        Class targetClass = [CDVSceneDelegate class];
+        
+        NSLog(@"[UniversalLinks] Using CDVSceneDelegate class: %@", targetClass);
+
+        SEL originalSEL = @selector(scene:continueUserActivity:);
+        SEL swizzledSEL = @selector(culPlugin_scene:continueUserActivity:);
+        
+        Method originalMethod = class_getInstanceMethod(targetClass, originalSEL);
+        Method swizzledMethod = class_getInstanceMethod(targetClass, swizzledSEL);
+        
+        NSLog(@"[UniversalLinks] Original method: %@, Swizzled method: %@",
+              originalMethod ? @"FOUND" : @"NOT FOUND",
+              swizzledMethod ? @"FOUND" : @"NOT FOUND");
+        
+        if (swizzledMethod) {
+            if (originalMethod) {
+                // Method exists - swizzle it
+                method_exchangeImplementations(originalMethod, swizzledMethod);
+                NSLog(@"[UniversalLinks] Swizzled scene:continueUserActivity: in CDVSceneDelegate");
+            } else {
+                // Method doesn't exist - add it
+                IMP swizzledIMP = method_getImplementation(swizzledMethod);
+                const char *swizzledTypes = method_getTypeEncoding(swizzledMethod);
+                
+                BOOL didAdd = class_addMethod(targetClass, originalSEL, swizzledIMP, swizzledTypes);
+                if (didAdd) {
+                    NSLog(@"[UniversalLinks] Added scene:continueUserActivity: to CDVSceneDelegate");
+                } else {
+                    NSLog(@"[UniversalLinks]  Failed to add method");
+                }
+            }
+            NSLog(@"[UniversalLinks] ===== UniversalLinks Setup COMPLETE =====");
+        } else {
+            NSLog(@"[UniversalLinks]  ERROR: Swizzled method not found");
+        }
+    });
+}
+
+- (void)culPlugin_scene:(UIScene *)scene continueUserActivity:(NSUserActivity *)userActivity {
+    NSLog(@"[UniversalLinks] ===== UNIVERSAL LINK DETECTED =====");
+    NSLog(@"[UniversalLinks] 📱 scene:continueUserActivity: called");
+    NSLog(@"[UniversalLinks] Activity Type: %@", userActivity.activityType);
+    NSLog(@"[UniversalLinks] Webpage URL: %@", userActivity.webpageURL);
+    
+    BOOL handled = NO;
+    
+    // Handle Universal Links (NSUserActivityTypeBrowsingWeb) FIRST
+    if ([userActivity.activityType isEqualToString:NSUserActivityTypeBrowsingWeb] && userActivity.webpageURL != nil) {
+        NSLog(@"[UniversalLinks] This IS a Universal Link!");
+        NSLog(@"[UniversalLinks] URL: %@", userActivity.webpageURL);
+        
+        // Get the view controller from the scene
+        if ([scene isKindOfClass:[UIWindowScene class]]) {
+            NSLog(@"[UniversalLinks] Scene is UIWindowScene");
+            UIWindowScene *windowScene = (UIWindowScene *)scene;
+            UIWindow *window = windowScene.windows.firstObject;
+            NSLog(@"[UniversalLinks] Windows count: %lu", (unsigned long)windowScene.windows.count);
+            
+            if (window && window.rootViewController) {
+                NSLog(@"[UniversalLinks] Window and rootViewController found");
+                UIViewController *rootVC = window.rootViewController;
+                NSLog(@"[UniversalLinks] Root VC class: %@", NSStringFromClass([rootVC class]));
+                
+                // Get the Cordova view controller
+                if ([rootVC isKindOfClass:[CDVViewController class]]) {
+                    NSLog(@"[UniversalLinks] CDVViewController found");
+                    CDVViewController *cordovaVC = (CDVViewController *)rootVC;
+                    
+                    // Get instance of the plugin and let it handle the userActivity object
+                    CULPlugin *plugin = [cordovaVC getCommandInstance:PLUGIN_NAME];
+                    if (plugin != nil) {
+                        NSLog(@"[UniversalLinks] Plugin instance found, handling...");
+                        handled = [plugin handleUserActivity:userActivity];
+                        NSLog(@"[UniversalLinks] Plugin handled: %@", handled ? @"YES" : @"NO");
+                    } else {
+                        NSLog(@"[UniversalLinks] Plugin instance not found");
+                    }
+                } else {
+                    NSLog(@"[UniversalLinks] Root VC is not CDVViewController");
+                }
+            } else {
+                NSLog(@"[UniversalLinks] No window or rootViewController found");
+            }
+        } else {
+            NSLog(@"[UniversalLinks]  Scene is not UIWindowScene, it's: %@", NSStringFromClass([scene class]));
+        }
+        
+        if (handled) {
+            // We handled it, don't pass to other plugins
+            NSLog(@"[UniversalLinks] ===== END UNIVERSAL LINK HANDLING (handled by UniversalLinks) =====");
+            return;
+        }
+    } else {
+        NSLog(@"[UniversalLinks] Not a Universal Link");
+        NSLog(@"[UniversalLinks] Expected: %@ with webpageURL", NSUserActivityTypeBrowsingWeb);
+    }
+    
+    // Not our activity type or we didn't handle it - call through to any other swizzled implementations
+    // Due to method swizzling, this actually calls what was the "original" implementation
+    NSLog(@"[UniversalLinks] Passing to other handlers (calling swizzled method)...");
+    [self culPlugin_scene:scene continueUserActivity:userActivity];
+    
+    NSLog(@"[UniversalLinks] ===== END UNIVERSAL LINK HANDLING (passed to other handler) =====");
+}
+
+@end
+


### PR DESCRIPTION
With the old project path, the entitlements file cannot be placed correctly by the hook. This is a backwards compatible fix done with this guide: https://apache.github.io/cordova-ios/documentation/cordova/upgrading-8#Change-to-the-generated-app-project-naming